### PR TITLE
Backfill missing lab metadata (5 files)

### DIFF
--- a/Instructions/Labs/Lab - 1 - Work with trace and import it to Trace Parser.md
+++ b/Instructions/Labs/Lab - 1 - Work with trace and import it to Trace Parser.md
@@ -1,10 +1,15 @@
 ---
 lab:
-    title: 'Lab 1: Work with trace and import it into the Trace Parser tool'
-    module: 'Learning Path 01: Introduction to developing with finance and operations apps'
+  title: 'Lab 1: Work with trace and import it into the Trace Parser tool'
+  module: 'Learning Path 01: Introduction to developing with finance and operations
+    apps'
+  description: '**MB-500: Microsoft Dynamics 365: Finance and Operations Apps Developer**'
+  duration: 5 minutes
+  level: 100
+  islab: true
+  primarytopics:
+  - Dynamics 365
 ---
-
-
 
 **MB-500: Microsoft Dynamics 365: Finance and Operations Apps Developer**
 

--- a/Instructions/Labs/Lab - 2 - Create a data entity with a computed column.md
+++ b/Instructions/Labs/Lab - 2 - Create a data entity with a computed column.md
@@ -1,7 +1,13 @@
 ---
 lab:
-    title: 'Lab 2: Create a data entity with a computed column'
-    module: 'Learning Path 02: Build finance and operations apps'
+  title: 'Lab 2: Create a data entity with a computed column'
+  module: 'Learning Path 02: Build finance and operations apps'
+  description: '**MB-500: Microsoft Dynamics 365: Finance and Operations Apps Developer**'
+  duration: 5 minutes
+  level: 200
+  islab: true
+  primarytopics:
+  - Dynamics 365
 ---
 
 **MB-500: Microsoft Dynamics 365: Finance and Operations Apps Developer**

--- a/Instructions/Labs/Lab - 3 - Implement the SysExtensionSerializer framework.md
+++ b/Instructions/Labs/Lab - 3 - Implement the SysExtensionSerializer framework.md
@@ -1,9 +1,14 @@
 ---
 lab:
-    title: 'Lab 3: Implement the SysExtensionSerializer framework'
-    module: 'Learning Path 03: Extend finance and operations apps'
+  title: 'Lab 3: Implement the SysExtensionSerializer framework'
+  module: 'Learning Path 03: Extend finance and operations apps'
+  description: '**MB-500: Microsoft Dynamics 365: Finance and Operations Apps Developer**'
+  duration: 5 minutes
+  level: 100
+  islab: true
+  primarytopics:
+  - Dynamics 365
 ---
-
 
 **MB-500: Microsoft Dynamics 365: Finance and Operations Apps Developer**
 

--- a/Instructions/Labs/Lab - 4 - Create aggregate entity.md
+++ b/Instructions/Labs/Lab - 4 - Create aggregate entity.md
@@ -1,7 +1,13 @@
 ---
 lab:
-    title: 'Lab 4: Create an aggregate data entity'
-    module: 'Learning Path 04: Connect to finance and operations'
+  title: 'Lab 4: Create an aggregate data entity'
+  module: 'Learning Path 04: Connect to finance and operations'
+  description: '**MB-500: Microsoft Dynamics 365: Finance and Operations Apps Developer**'
+  duration: 5 minutes
+  level: 100
+  islab: true
+  primarytopics:
+  - Dynamics 365
 ---
 
 **MB-500: Microsoft Dynamics 365: Finance and Operations Apps Developer**

--- a/Instructions/Labs/Lab - 5 - Data management.md
+++ b/Instructions/Labs/Lab - 5 - Data management.md
@@ -1,9 +1,15 @@
 ---
 lab:
-    title: 'Lab 5: Import data using Data Management'
-    module: 'Learning Path 05: Migrate data and go live with finance and operations apps'
+  title: 'Lab 5: Import data using Data Management'
+  module: 'Learning Path 05: Migrate data and go live with finance and operations
+    apps'
+  description: '**MB-500: Microsoft Dynamics 365: Finance and Operations Apps Developer**'
+  duration: 5 minutes
+  level: 100
+  islab: true
+  primarytopics:
+  - Dynamics 365
 ---
-
 
 **MB-500: Microsoft Dynamics 365: Finance and Operations Apps Developer**
 


### PR DESCRIPTION
This PR backfills missing lab metadata in markdown files.

Rules used:
- Add-only (does not overwrite existing metadata keys)
- Keys: lab.title, lab.description, lab.duration, lab.level, lab.islab
- Optional casing normalization to lowercase when enabled

Files changed: 5

- `Instructions/Labs/Lab - 1 - Work with trace and import it to Trace Parser.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/Lab - 2 - Create a data entity with a computed column.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/Lab - 3 - Implement the SysExtensionSerializer framework.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/Lab - 4 - Create aggregate entity.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/Lab - 5 - Data management.md` (description,duration,level,islab,primarytopics)
