### PR TITLE
Backfill missing lab metadata (5 files)

### DIFF
--- a/Instructions/Labs/Lab - 1 - Work with trace and import it to Trace Parser.md
+++ b/Instructions/Labs/Lab - 1 - Work with trace and import it to Trace Parser.md
@@ -3,8 +3,8 @@ lab:
   title: 'Lab 1: Work with trace and import it into the Trace Parser tool'
   module: 'Learning Path 01: Introduction to developing with finance and operations apps'
   description: In this scenario, users have reported that sales orders are working slowly, so you’ll need to review the sales order lines and check reservations against on-hand supply.
-  duration: 5 minutes
-  level: 100
+  duration: 25 minutes
+  level: 300
   islab: true
 ---
 
@@ -265,6 +265,7 @@ To analyze X++ and SQL for users in the Trace Parser tool:
 9. You now can evaluate options such as rewriting the query or the code which calls it, creating indexes, or other.
 
     
+
 
 
 

--- a/Instructions/Labs/Lab - 1 - Work with trace and import it to Trace Parser.md
+++ b/Instructions/Labs/Lab - 1 - Work with trace and import it to Trace Parser.md
@@ -1,10 +1,12 @@
 ---
 lab:
-    title: 'Lab 1: Work with trace and import it into the Trace Parser tool'
-    module: 'Learning Path 01: Introduction to developing with finance and operations apps'
+  title: 'Lab 1: Work with trace and import it into the Trace Parser tool'
+  module: 'Learning Path 01: Introduction to developing with finance and operations apps'
+  description: In this scenario, users have reported that sales orders are working slowly, so you’ll need to review the sales order lines and check reservations against on-hand supply.
+  duration: 5 minutes
+  level: 100
+  islab: true
 ---
-
-
 
 **MB-500: Microsoft Dynamics 365: Finance and Operations Apps Developer**
 

--- a/Instructions/Labs/Lab - 2 - Create a data entity with a computed column.md
+++ b/Instructions/Labs/Lab - 2 - Create a data entity with a computed column.md
@@ -3,8 +3,8 @@ lab:
   title: 'Lab 2: Create a data entity with a computed column'
   module: 'Learning Path 02: Build finance and operations apps'
   description: 'In the first exercise, you’ll create a data entity for a customer with the following fields:'
-  duration: 5 minutes
-  level: 200
+  duration: 60 minutes
+  level: 300
   islab: true
 ---
 
@@ -302,6 +302,7 @@ To test your new data entity in SQL Server Management Studio:
 
 You have now created a data entity which can be used to integrate with external systems, 
 and you have made it more useful by adding computed columns.
+
 
 
 

--- a/Instructions/Labs/Lab - 2 - Create a data entity with a computed column.md
+++ b/Instructions/Labs/Lab - 2 - Create a data entity with a computed column.md
@@ -1,7 +1,11 @@
 ---
 lab:
-    title: 'Lab 2: Create a data entity with a computed column'
-    module: 'Learning Path 02: Build finance and operations apps'
+  title: 'Lab 2: Create a data entity with a computed column'
+  module: 'Learning Path 02: Build finance and operations apps'
+  description: 'In the first exercise, you’ll create a data entity for a customer with the following fields:'
+  duration: 5 minutes
+  level: 200
+  islab: true
 ---
 
 **MB-500: Microsoft Dynamics 365: Finance and Operations Apps Developer**

--- a/Instructions/Labs/Lab - 2 - Create a data entity with a computed column.md
+++ b/Instructions/Labs/Lab - 2 - Create a data entity with a computed column.md
@@ -2,7 +2,7 @@
 lab:
   title: 'Lab 2: Create a data entity with a computed column'
   module: 'Learning Path 02: Build finance and operations apps'
-  description: 'In the first exercise, you’ll create a data entity for a customer with the following fields:'
+  description: 'We’ll create a data entity with a computed column, and view its data using different methods'
   duration: 60 minutes
   level: 300
   islab: true
@@ -302,6 +302,7 @@ To test your new data entity in SQL Server Management Studio:
 
 You have now created a data entity which can be used to integrate with external systems, 
 and you have made it more useful by adding computed columns.
+
 
 
 

--- a/Instructions/Labs/Lab - 3 - Implement the SysExtensionSerializer framework.md
+++ b/Instructions/Labs/Lab - 3 - Implement the SysExtensionSerializer framework.md
@@ -1,9 +1,12 @@
 ---
 lab:
-    title: 'Lab 3: Implement the SysExtensionSerializer framework'
-    module: 'Learning Path 03: Extend finance and operations apps'
+  title: 'Lab 3: Implement the SysExtensionSerializer framework'
+  module: 'Learning Path 03: Extend finance and operations apps'
+  description: <html <table<tr<thVersion</th<thDate</th<thChange</th</tr <tr<td1.0</td<td23 Aug 2024</td<tdInitial release</td</tr <tr<td1.1</td<td10 Dec 2024</td<tdWorkaround for expired certificate</td</tr <tr<td1.2</td<td15 Jan 2025</td<tdAdded business scenario</td</tr <tr<td1.3</td<td19 Feb 2025</td<tdAdded The Why</td</tr <tr<td1.4</td<td21 Aug 2025</td<tdApp version has been updated to 10.0.41</td</tr <tr<td1.5</td<td14 Oct 2025</td<tdInstruction cleanup</td</tr <tr<td1.6</td<td09 Feb 2026</td<tdClarifying instruction cleanup</td</tr </table </html
+  duration: 5 minutes
+  level: 100
+  islab: true
 ---
-
 
 **MB-500: Microsoft Dynamics 365: Finance and Operations Apps Developer**
 

--- a/Instructions/Labs/Lab - 3 - Implement the SysExtensionSerializer framework.md
+++ b/Instructions/Labs/Lab - 3 - Implement the SysExtensionSerializer framework.md
@@ -3,8 +3,8 @@ lab:
   title: 'Lab 3: Implement the SysExtensionSerializer framework'
   module: 'Learning Path 03: Extend finance and operations apps'
   description: <html <table<tr<thVersion</th<thDate</th<thChange</th</tr <tr<td1.0</td<td23 Aug 2024</td<tdInitial release</td</tr <tr<td1.1</td<td10 Dec 2024</td<tdWorkaround for expired certificate</td</tr <tr<td1.2</td<td15 Jan 2025</td<tdAdded business scenario</td</tr <tr<td1.3</td<td19 Feb 2025</td<tdAdded The Why</td</tr <tr<td1.4</td<td21 Aug 2025</td<tdApp version has been updated to 10.0.41</td</tr <tr<td1.5</td<td14 Oct 2025</td<tdInstruction cleanup</td</tr <tr<td1.6</td<td09 Feb 2026</td<tdClarifying instruction cleanup</td</tr </table </html
-  duration: 5 minutes
-  level: 100
+  duration: 55 minutes
+  level: 300
   islab: true
 ---
 
@@ -561,6 +561,7 @@ To test modifications:
 > Note: This will not apply, of course, without a successful build.
 
 12. You have now successfully added fields via code, updated them via the user interface, and examined them using the browser.
+
 
 
 

--- a/Instructions/Labs/Lab - 3 - Implement the SysExtensionSerializer framework.md
+++ b/Instructions/Labs/Lab - 3 - Implement the SysExtensionSerializer framework.md
@@ -2,7 +2,7 @@
 lab:
   title: 'Lab 3: Implement the SysExtensionSerializer framework'
   module: 'Learning Path 03: Extend finance and operations apps'
-  description: <html <table<tr<thVersion</th<thDate</th<thChange</th</tr <tr<td1.0</td<td23 Aug 2024</td<tdInitial release</td</tr <tr<td1.1</td<td10 Dec 2024</td<tdWorkaround for expired certificate</td</tr <tr<td1.2</td<td15 Jan 2025</td<tdAdded business scenario</td</tr <tr<td1.3</td<td19 Feb 2025</td<tdAdded The Why</td</tr <tr<td1.4</td<td21 Aug 2025</td<tdApp version has been updated to 10.0.41</td</tr <tr<td1.5</td<td14 Oct 2025</td<tdInstruction cleanup</td</tr <tr<td1.6</td<td09 Feb 2026</td<tdClarifying instruction cleanup</td</tr </table </html
+  description: 'We will create an aggregated data entity, and then test it.'
   duration: 55 minutes
   level: 300
   islab: true
@@ -561,6 +561,7 @@ To test modifications:
 > Note: This will not apply, of course, without a successful build.
 
 12. You have now successfully added fields via code, updated them via the user interface, and examined them using the browser.
+
 
 
 

--- a/Instructions/Labs/Lab - 4 - Create aggregate entity.md
+++ b/Instructions/Labs/Lab - 4 - Create aggregate entity.md
@@ -1,7 +1,11 @@
 ---
 lab:
-    title: 'Lab 4: Create an aggregate data entity'
-    module: 'Learning Path 04: Connect to finance and operations'
+  title: 'Lab 4: Create an aggregate data entity'
+  module: 'Learning Path 04: Connect to finance and operations'
+  description: <html <table<tr<thVersion</th<thDate</th<thChange</th</tr <tr<td1.0</td<td23 Aug 2024</td<tdInitial release</td</tr <tr<td1.1</td<td10 Dec 2024</td<tdWorkaround for expired certificate</td</tr <tr<td1.2</td<td15 Jan 2025</td<tdAdded business scenario</td</tr <tr<td1.3</td<td19 Feb 2025</td<tdAdded The Why</td</tr <tr<td1.4</td<td21 Aug 2025</td<tdApp version has been updated to 10.0.41</td</tr <tr<td1.5</td<td14 Oct 2025</td<tdInstruction cleanup</td</tr <tr<td1.6</td<td09 Feb 2026</td<tdClarifying instruction cleanup</td</tr </table </html
+  duration: 5 minutes
+  level: 100
+  islab: true
 ---
 
 **MB-500: Microsoft Dynamics 365: Finance and Operations Apps Developer**

--- a/Instructions/Labs/Lab - 4 - Create aggregate entity.md
+++ b/Instructions/Labs/Lab - 4 - Create aggregate entity.md
@@ -2,9 +2,9 @@
 lab:
   title: 'Lab 4: Create an aggregate data entity'
   module: 'Learning Path 04: Connect to finance and operations'
-  description: <html <table<tr<thVersion</th<thDate</th<thChange</th</tr <tr<td1.0</td<td23 Aug 2024</td<tdInitial release</td</tr <tr<td1.1</td<td10 Dec 2024</td<tdWorkaround for expired certificate</td</tr <tr<td1.2</td<td15 Jan 2025</td<tdAdded business scenario</td</tr <tr<td1.3</td<td19 Feb 2025</td<tdAdded The Why</td</tr <tr<td1.4</td<td21 Aug 2025</td<tdApp version has been updated to 10.0.41</td</tr <tr<td1.5</td<td14 Oct 2025</td<tdInstruction cleanup</td</tr <tr<td1.6</td<td09 Feb 2026</td<tdClarifying instruction cleanup</td</tr </table </html
-  duration: 5 minutes
-  level: 100
+  description: In this lab, we will create an aggregated data entity, and then test it.
+  duration: 25 minutes
+  level: 300
   islab: true
 ---
 
@@ -275,4 +275,5 @@ To test an aggregate data entity:
     grouped by **ItemId**
 
 ![A screenshot of output from aggregated data entity.](media/L4P05.png)
+
 

--- a/Instructions/Labs/Lab - 5 - Data management.md
+++ b/Instructions/Labs/Lab - 5 - Data management.md
@@ -2,9 +2,9 @@
 lab:
   title: 'Lab 5: Import data using Data Management'
   module: 'Learning Path 05: Migrate data and go live with finance and operations apps'
-  description: then wait for the 140 – Accounts receivable template to load. When it completes you will see entities in the Entities list. (If you don't, then the entity list has probably not refreshed yet.)
-  duration: 5 minutes
-  level: 100
+  description: We will set updata management, prepare templates, and then import data.
+  duration: 30 minutes
+  level: 300
   islab: true
 ---
 
@@ -230,6 +230,7 @@ To create an import project:
 37. The **Execution Status** should change to **Succeeded**.
 
 38. Select **View execution log**, and then verify that there are no errors.
+
 
 
 

--- a/Instructions/Labs/Lab - 5 - Data management.md
+++ b/Instructions/Labs/Lab - 5 - Data management.md
@@ -1,9 +1,12 @@
 ---
 lab:
-    title: 'Lab 5: Import data using Data Management'
-    module: 'Learning Path 05: Migrate data and go live with finance and operations apps'
+  title: 'Lab 5: Import data using Data Management'
+  module: 'Learning Path 05: Migrate data and go live with finance and operations apps'
+  description: then wait for the 140 – Accounts receivable template to load. When it completes you will see entities in the Entities list. (If you don't, then the entity list has probably not refreshed yet.)
+  duration: 5 minutes
+  level: 100
+  islab: true
 ---
-
 
 **MB-500: Microsoft Dynamics 365: Finance and Operations Apps Developer**
 


### PR DESCRIPTION
This PR backfills missing lab metadata in markdown files.

Rules used:
- Add-only (does not overwrite existing metadata keys)
- Keys: lab.title, lab.description, lab.duration, lab.level, lab.islab
- Optional casing normalization to lowercase when enabled

Files changed: 5

- `Instructions/Labs/Lab - 1 - Work with trace and import it to Trace Parser.md` (description,duration,level,islab)
- `Instructions/Labs/Lab - 2 - Create a data entity with a computed column.md` (description,duration,level,islab)
- `Instructions/Labs/Lab - 3 - Implement the SysExtensionSerializer framework.md` (description,duration,level,islab)
- `Instructions/Labs/Lab - 4 - Create aggregate entity.md` (description,duration,level,islab)
- `Instructions/Labs/Lab - 5 - Data management.md` (description,duration,level,islab)
